### PR TITLE
commenting common.jl to avoid cloning issues

### DIFF
--- a/src/ops/common.jl
+++ b/src/ops/common.jl
@@ -1,0 +1,2 @@
+# This should be common place for basic functions which can be fused for example.
+


### PR DESCRIPTION
Purely empty file might cause cloning issues on windows platform.