### PR TITLE
Allowing other argument types other thant WgpuArray types

### DIFF
--- a/examples/relu_kernel.jl
+++ b/examples/relu_kernel.jl
@@ -4,18 +4,14 @@ using MacroTools
 y = WgpuArray((rand(4, 4) .-0.5) .|> Float32)
 
 function relu_kernel(x::WgpuArray{T, N}, out::WgpuArray{T, N}) where {T, N}
-	xdim = workgroupDims.x
-	ydim = workgroupDims.y
-	gIdx = workgroupId.x*xdim + localId.x
-	gIdy = workgroupId.y*ydim + localId.y
-	gId = xDims.x*gIdy + gIdx
+	gId = xDims.x*globalId.y + globalId.x
 	value = x[gId]
 	out[gId] = max(value, 0.0)
 end
 
 function relu(x::WgpuArray{T, N}) where {T, N}
 	y = similar(x)
-	@wgpukernel launch=true workgrouSizes=(4,4) workgroupCount=(1,1) relu_kernel(x, y)
+	@wgpukernel launch=true workgroupSizes=(4,4) workgroupCount=(1,1) relu_kernel(x, y)
 	return y
 end
 

--- a/src/WGPUCompute.jl
+++ b/src/WGPUCompute.jl
@@ -18,6 +18,9 @@ include("compiler/execution.jl")
 include("broadcast.jl")
 include("shaders.jl")
 
+# array implementations
+include("gpuArrays.jl")
+
 abstract type AbstractLayer{T} end 
 
 """

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -3,17 +3,11 @@
 using Base.Broadcast: BroadcastStyle, Broadcasted
 
 struct WgpuArrayStyle{N} <: AbstractGPUArrayStyle{N} end
+
 WgpuArrayStyle(::Val{N}) where N = WgpuArrayStyle{N}()
 WgpuArrayStyle{M}(::Val{N}) where {N,M} = WgpuArrayStyle{N}()
 
 BroadcastStyle(::Type{<:WgpuArray{T,N}}) where {T,N} = WgpuArrayStyle{N}()
 
-#Base.similar(bc::Broadcasted{WgpuArrayStyle{N}}, ::Type{T}) where {N,T} =
-#    similar(WgpuArray{T}, axes(bc))
-
 Base.similar(bc::Broadcasted{WgpuArrayStyle{N}}, ::Type{T}, dims) where {N,T} =
     Base.similar(WgpuArray{T, length(dims)}, dims)
-
-# broadcasting type ctors isnt GPU compatible
-Broadcast.broadcasted(::WgpuArrayStyle{N}, f::Type{T}, args...) where {N, T} =
-    Broadcasted{WgpuArrayStyle{N}}((x...) -> T(x...), args, nothing)

--- a/src/gpuArrays.jl
+++ b/src/gpuArrays.jl
@@ -1,0 +1,5 @@
+struct WgpuArrayBackend <: AbstractGPUBackend end
+
+struct WgpuKernelContext <: AbstractKernelContext end
+
+GPUArrays.backend(::Type{<:WgpuArray}) = WgpuArrayBackend()

--- a/src/ops/cast.jl
+++ b/src/ops/cast.jl
@@ -1,0 +1,15 @@
+function cast_kernel(x::WgpuArray{T, N}, out::WgpuArray{S, N}) where {T, S, N}
+	xdim = workgroupDims.x
+	ydim = workgroupDims.y
+	gIdx = workgroupId.x*xdim + localId.x
+	gIdy = workgroupId.y*ydim + localId.y
+	gId = xDims.x*gIdy + gIdx
+	out[gId] = S(ceil(x[gId]))
+end	
+
+function cast(S::DataType, x::WgpuArray{T, N}) where {T, N}
+	y = WgpuArray{S}(undef, size(x))
+	@wgpukernel launch=true workgroupSizes=(4, 4) workgroupCount=(2, 2) cast_kernel(x, y)
+	return y
+end	
+

--- a/src/ops/clamp.jl
+++ b/src/ops/clamp.jl
@@ -1,0 +1,15 @@
+using Revise
+using WGPUCompute
+
+function clamp_kernel(x::WgpuArray{T, N}, out::WgpuArray{T, N}, minval::T, maxval::T) where {T, N}
+	gId = xDims.x*globalId.y + globalId.x
+	value = x[gId]
+	out[gId] = clamp(value, minval, maxval)
+end
+
+
+function clamp(x::WgpuArray{T, N}, minValue::T, maxValue::T) where {T, N}
+	y = similar(x)
+	@wgpukernel launch=true workgroupSizes=(4, 4) workgroupCount=(2, 2) clamp_kernel(x, y, minValue, maxValue)
+	return y
+end


### PR DESCRIPTION
fixes #11

Enables elementwise kernels to pass other types like Floats etc... 

worked on clamp.jl as an example in op folder