### PR TITLE
created clamp kernel example

### DIFF
--- a/examples/clamp_kernel.jl
+++ b/examples/clamp_kernel.jl
@@ -1,0 +1,20 @@
+using Revise
+using WGPUCompute
+
+function clamp_kernel(x::WgpuArray{T, N}, out::WgpuArray{T, N}, minval::T, maxval::T) where {T, N}
+	gId = xDims.x*globalId.y + globalId.x
+	value = x[gId]
+	out[gId] = clamp(value, minval, maxval)
+end
+
+
+function Base.clamp(x::WgpuArray{T, N}, minValue::T, maxValue::T) where {T, N}
+	y = similar(x)
+	@wgpukernel launch=true workgroupSizes=size(y) workgroupCount=(1, 1) clamp_kernel(x, y, minValue, maxValue)
+	return y
+end
+
+x = WgpuArray{Float32, 2}(rand(16, 16))
+
+y = Base.clamp(x, 0.2f0, 0.5f0)
+


### PR DESCRIPTION
An example to clamp. Type parameters in scalar arguments is now possible with https://github.com/JuliaWGPU/WGPUTranspiler.jl/pull/24