### PR TITLE
Tiled matrix multiplication example demonstrating shared memory api and usage

### DIFF
--- a/examples/matmul_kernel.jl
+++ b/examples/matmul_kernel.jl
@@ -4,8 +4,8 @@ using Infiltrator
 using Test
 
 function naive_matmul_kernel(x::WgpuArray{T, N}, y::WgpuArray{T, N}, out::WgpuArray{T, N}) where {T, N}
-	gIdx = localId.x
-	gIdy = localId.y
+	gIdx = globalId.x
+	gIdy = globalId.y
 	gId = xDims.x*gIdy + gIdx
 	out[gId] = 0.0
 	sum = 0.0

--- a/examples/tiled_matmul_kernel.jl
+++ b/examples/tiled_matmul_kernel.jl
@@ -1,6 +1,6 @@
 using Revise
 using WGPUCompute
-
+using Test
 using StaticArrays
 
 const Vec2{T} = SVector{2, T}
@@ -11,21 +11,43 @@ const Mat3{T} = SMatrix{3, 3, T, 9}
 const Mat4{T} = SMatrix{4, 4, T, 16}
 const Vec{N, T} = SVector{N, T}
 
-
 x = WgpuArray{Float32, 2}(rand(16, 16));
 y = WgpuArray{Float32, 2}(rand(16, 16));
 
 function tiled_matmul_kernel(x::WgpuArray{T, N}, y::WgpuArray{T, N}, out::WgpuArray{T, N}) where {T, N}
-	gIdx = localId.x
-	gIdy = localId.y
+	lIdx = localId.x
+	lIdy = localId.y
+	gIdx = globalId.x
+	gIdy = globalId.y
+	
+	#set out matrix to zero
 	gId = xDims.x*gIdy + gIdx
 	out[gId] = 0.0
+	
+	# set local variable = 0.0
 	sum = 0.0
-	for i in 0:xDims.y
-		xIdx = xDims.x*i + gIdx
-		yIdx = yDims.x*gIdy + i
-		sum = sum + x[xIdx]*y[yIdx]
+	
+	for wi in 0:numWorkgroups.x
+		# copy block from x to shared memory
+		xIdx = workgroupId.y*workgroupDims.x + localId.x
+		xIdy = workgroupId.x*workgroupDims.y + localId.y
+		sIdx = localId.y*workgroupDims.x + localId.x
+		shmem1[sIdx] = x[xIdy*xDims.x + xIdx]
+		
+		# copy block from y to shared memory
+		yIdx = workgroupId.x*workgroupDims.x + workgroupId.x
+		yIdy = workgroupId.y*workgroupDims.y + workgroupId.y
+		sIdx = localId.y*workgroupDims.x + localId.x
+		shmem2[sIdx] = y[yIdy*yDims.x + yIdx]
+		synchronize()
+		
+		# block sums for each tid
+		for i in 0:workgroupDims.y
+			sum = sum + shmem1[i*workgroupDims.x + localId.x]*shmem2[localId.y*workgroupDims.x + i]
+		end
+		synchronize()
 	end
+	
 	out[gId] = sum
 end
 
@@ -39,9 +61,9 @@ function tiled_matmul(x::WgpuArray{T, N}, y::WgpuArray{T, N}) where {T, N}
 	wgSize = (16, 16)
 	@wgpukernel(
 		launch=true,
-		workgroupSizes=outSize,
-		workgroupCount=(1, 1),
-		shmem=(:shmem1=>(Vec4{Float32}, (4, 4)), :shmem2=>(Float32, (4, 4))),
+		workgroupSizes=(4, 4),
+		workgroupCount=(4, 4),
+		shmem=(:shmem1=>(Float32, (4, 4)), :shmem2=>(Float32, (4, 4))),
 		tiled_matmul_kernel(x, y, out)
 	)
 	return out
@@ -50,3 +72,7 @@ end
 Base.:*(x::WgpuArray{T, N}, y::WgpuArray{T, N})  where {T, N} = tiled_matmul(x, y)
 
 z = x*y
+
+z_cpu = (x |> collect)*(y |> collect)
+
+@test z_cpu == (z |> collect)


### PR DESCRIPTION
* Shared memory can be declared in kernel (type and length is essential; which is different from CUDA.jl)
* Private memory interface can also be along these lines.
